### PR TITLE
Remove stratify for regression splits

### DIFF
--- a/feature_selector/feature_selector.py
+++ b/feature_selector/feature_selector.py
@@ -303,7 +303,10 @@ class FeatureSelector():
             # If training using early stopping need a validation set
             if early_stopping:
                 
-                train_features, valid_features, train_labels, valid_labels = train_test_split(features, labels, test_size = 0.15, stratify=labels)
+                if task == 'classification':
+                    train_features, valid_features, train_labels, valid_labels = train_test_split(features, labels, test_size = 0.15, stratify=labels)
+                elif task == 'regression':
+                    train_features, valid_features, train_labels, valid_labels = train_test_split(features, labels, test_size = 0.15)
 
                 # Train the model with early stopping
                 model.fit(train_features, train_labels, eval_metric = eval_metric,


### PR DESCRIPTION
Hey Will!
1. The current code results in the following error for regression tasks:
`ValueError: The least populated class in y has only 1 member, which is too few. The minimum number of groups for any class cannot be less than 2.`
It's because `stratify`  works based on class labels, hence only for classification.
This would **not affect** your Jupyter notebooks, as it leaves your classification example untouched.

2. I'd also set the `random_state` parameter to get the same train/test split every time, but that's up to you.
